### PR TITLE
Add glitch-soc skin installer and glitch flavour styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read the blog post: [The day I decided to build my own "Twitter"](https://rolle.
 2. [Features](#features)
 3. [List of instances that use Mastodon Bird UI](#list-of-instances-that-use-mastodon-bird-ui)
 4. [Installation for Mastodon instance admins](#installation-for-mastodon-instance-admins)
-5. [Make Mastodon Bird UI as optional by integrating it as 'Site theme' in settings for all users](#make-mastodon-bird-ui-as-optional-by-integrating-it-as-site-theme-in-settings-for-all-users)
+5. [Make Mastodon Bird UI available as a glitch-soc skin](#make-mastodon-bird-ui-available-as-a-glitch-soc-skin)
 6. [Installation for regular users, contributing and testing](#installation-for-regular-users-contributing-and-testing)
 7. [Development](#development)
 8. [Updating instructions](#updating-instructions)
@@ -155,11 +155,11 @@ The following instances have enabled Mastodon Bird UI for their users, based on 
 
 ![Screen-Shot-2023-03-31-13-25-52](https://user-images.githubusercontent.com/1534150/229111630-c8975708-134b-4887-b259-a87857193387.png)
 
-## Make Mastodon Bird UI as optional by integrating it as 'Site theme' in settings for all users
+## Make Mastodon Bird UI available as a glitch-soc skin
 
-Mastodon Bird UI can be integrated as a **Site theme** for all instance users as optional.
+This branch targets [glitch-soc](https://github.com/glitch-soc/mastodon) and installs Mastodon Bird UI as a **skin** for the built-in `glitch` flavour. glitch-soc does not use upstream Mastodon's `config/themes.yml` site-theme pipeline for flavour styling; a skin lives under `app/javascript/skins/glitch/<skin-name>/` and is selected together with the `glitch` flavour.
 
-**Please note**: This requires Mastodon v4.6.0+ and modifies Mastodon's styles directory. Do this at your own risk! I recommend testing in a development environment first.
+**Please note**: This requires glitch-soc with the `glitch` flavour and modifies the instance's `app/javascript/skins/glitch/` directory. Do this at your own risk! I recommend testing in a development environment first.
 
 ![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/1534150/b30f19e2-2835-4d92-b40d-cac9922f64b3)
 
@@ -173,13 +173,15 @@ Clone this repository and run the install script:
 git clone https://github.com/ronilaukkarinen/mastodon-bird-ui.git
 cd mastodon-bird-ui
 npm install
-sudo bash scripts/install-to-mastodon.sh --path /path/to/mastodon
+sudo bash scripts/install-to-mastodon.sh --path /path/to/glitch-soc
 ```
 
 The script will:
-- Copy Bird UI source files to `app/javascript/styles/mastodon-bird-ui/`
-- Generate theme entry points for all variants (dark, light, contrast, accessible, etc.)
-- Update `config/themes.yml` with the new themes
+- Verify the target instance has `app/javascript/flavours/glitch/theme.yml`
+- Copy Bird UI source files to `app/javascript/skins/glitch/mastodon-bird-ui/mastodon-bird-ui/`
+- Generate `common.scss` skin packs that first import `@/flavours/glitch/styles/application` and then apply Bird UI overrides
+- Add optional accessible skin variants when run with `--variations`
+- Optionally set `flavour: 'glitch'` and `skin: 'mastodon-bird-ui'` in `config/settings.yml` when run with `--default`
 
 After running the script, rebuild assets and restart services:
 
@@ -192,7 +194,7 @@ sudo systemctl restart mastodon-web
 RAILS_ENV=development bundle exec rails assets:precompile
 ```
 
-Users can now select Bird UI themes in Preferences > Appearance.
+Users can now select the `glitch` flavour and `Mastodon Bird UI` skin in Preferences > Flavours.
 
 ## Installation for regular users
 
@@ -278,12 +280,12 @@ If your Mastodon instance is not at `mementomori.test`, edit `bs-config.js` and 
 
 If you are using **Custom CSS**, just copy and paste the new version of `dist/mastodon-bird-ui.css` to **Custom CSS** textarea in the Appearance settings in your instance (https://_yourinstance_/admin/settings/appearance).
 
-If you are using Mastodon Bird UI as a site theme, update to the latest version:
+If you are using Mastodon Bird UI as a glitch-soc skin, update to the latest version:
 
 ```bash
 cd mastodon-bird-ui
 git pull
-sudo bash scripts/install-to-mastodon.sh --path /path/to/mastodon
+sudo bash scripts/install-to-mastodon.sh --path /path/to/glitch-soc
 ```
 
 Then rebuild assets and restart:

--- a/dist/mastodon-bird-ui.css
+++ b/dist/mastodon-bird-ui.css
@@ -2977,7 +2977,7 @@ body.layout-single-column, body.layout-multiple-columns {
   display: none;
 }
 
-.layout-single-column .icon-user-plus.column-link__icon path, .layout-single-column .icon.icon-undefined path, .layout-single-column .icon.icon-users path, .layout-single-column [class*="_comp_account_header__buttons"] .optional path, .layout-single-column [class*="_comp_account_header__buttons"] .icon.icon-user-plus path, .layout-single-column .notification__filter-bar .icon.icon-user-plus path, .layout-single-column [class*="_comp_account_header__buttons"] .icon.icon-tasks path, .layout-single-column .notification__filter-bar .icon.icon-tasks path, .layout-single-column .icon.icon-wrapstodon-planet path, .layout-single-column .navigation-panel__legal .column-link[href="/about"] path, .layout-multiple-columns .icon-user-plus.column-link__icon path, .layout-multiple-columns .icon.icon-undefined path, .layout-multiple-columns .icon.icon-users path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .optional path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .icon.icon-user-plus path, .layout-multiple-columns .notification__filter-bar .icon.icon-user-plus path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .icon.icon-tasks path, .layout-multiple-columns .notification__filter-bar .icon.icon-tasks path, .layout-multiple-columns .icon.icon-wrapstodon-planet path, .layout-multiple-columns .navigation-panel__legal .column-link[href="/about"] path {
+.layout-single-column .icon-user-plus.column-link__icon path, .layout-single-column .icon.icon-undefined path, .layout-single-column .icon.icon-users path, .layout-single-column .icon.icon-swap-horiz path, .layout-single-column [class*="_comp_account_header__buttons"] .optional path, .layout-single-column [class*="_comp_account_header__buttons"] .icon.icon-user-plus path, .layout-single-column .notification__filter-bar .icon.icon-user-plus path, .layout-single-column [class*="_comp_account_header__buttons"] .icon.icon-tasks path, .layout-single-column .notification__filter-bar .icon.icon-tasks path, .layout-single-column .icon.icon-wrapstodon-planet path, .layout-single-column .navigation-panel__legal .column-link[href="/about"] path, .layout-multiple-columns .icon-user-plus.column-link__icon path, .layout-multiple-columns .icon.icon-undefined path, .layout-multiple-columns .icon.icon-users path, .layout-multiple-columns .icon.icon-swap-horiz path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .optional path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .icon.icon-user-plus path, .layout-multiple-columns .notification__filter-bar .icon.icon-user-plus path, .layout-multiple-columns [class*="_comp_account_header__buttons"] .icon.icon-tasks path, .layout-multiple-columns .notification__filter-bar .icon.icon-tasks path, .layout-multiple-columns .icon.icon-wrapstodon-planet path, .layout-multiple-columns .navigation-panel__legal .column-link[href="/about"] path {
   display: block;
 }
 
@@ -4258,6 +4258,222 @@ body.embed .entry .detailed-status {
   overflow: hidden;
   border: 0 !important;
   border-radius: 0 !important;
+}
+
+.layout-single-column .glitch.local-settings, .layout-multiple-columns .glitch.local-settings {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  box-shadow: var(--dropdown-shadow);
+  color: var(--color-fg);
+  max-width: min(860px, 92vw);
+  max-height: min(640px, 90vh);
+  overflow: hidden;
+}
+
+.layout-single-column .glitch.local-settings__navigation, .layout-multiple-columns .glitch.local-settings__navigation {
+  background: var(--color-dark);
+  border-right: 1px solid var(--color-border);
+  scrollbar-width: none;
+}
+
+.layout-single-column .glitch.local-settings__navigation::-webkit-scrollbar {
+  width: 4px;
+  display: none;
+}
+
+.layout-single-column .glitch.local-settings__page::-webkit-scrollbar {
+  width: 4px;
+  display: none;
+}
+
+.layout-multiple-columns .glitch.local-settings__navigation::-webkit-scrollbar {
+  width: 4px;
+  display: none;
+}
+
+.layout-multiple-columns .glitch.local-settings__page::-webkit-scrollbar {
+  width: 4px;
+  display: none;
+}
+
+.layout-single-column .glitch.local-settings__navigation__item, .layout-multiple-columns .glitch.local-settings__navigation__item {
+  color: var(--color-light-text);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight-semibold);
+  background: none;
+  border-bottom: 0;
+  gap: 10px;
+  padding: 14px 18px;
+  transition: background-color .2s, color .2s;
+}
+
+.layout-single-column .glitch.local-settings__navigation__item.active, .layout-single-column .glitch.local-settings__navigation__item:hover, .layout-single-column .glitch.local-settings__navigation__item:focus, .layout-multiple-columns .glitch.local-settings__navigation__item.active, .layout-multiple-columns .glitch.local-settings__navigation__item:hover, .layout-multiple-columns .glitch.local-settings__navigation__item:focus {
+  background: var(--color-column-link-hover);
+  color: var(--color-fg);
+}
+
+.layout-single-column .glitch.local-settings__navigation__item.close, .layout-single-column .glitch.local-settings__navigation__item.close:hover, .layout-single-column .glitch.local-settings__navigation__item.close:focus, .layout-multiple-columns .glitch.local-settings__navigation__item.close, .layout-multiple-columns .glitch.local-settings__navigation__item.close:hover, .layout-multiple-columns .glitch.local-settings__navigation__item.close:focus {
+  background: var(--color-red);
+  color: #fff;
+}
+
+.layout-single-column .glitch.local-settings__page, .layout-multiple-columns .glitch.local-settings__page {
+  background: var(--color-bg);
+  color: var(--color-fg);
+  padding: 20px;
+}
+
+.layout-single-column .glitch.local-settings h1, .layout-multiple-columns .glitch.local-settings h1 {
+  color: var(--color-fg);
+  font-size: var(--font-size-heading);
+  font-weight: var(--font-weight-bold);
+}
+
+.layout-single-column .glitch.local-settings h2, .layout-single-column .glitch.local-settings span.hint, .layout-single-column .deprecated-settings-info, .layout-multiple-columns .glitch.local-settings h2, .layout-multiple-columns .glitch.local-settings span.hint, .layout-multiple-columns .deprecated-settings-info {
+  color: var(--color-dim);
+}
+
+.layout-single-column .glitch.local-settings__page__item, .layout-multiple-columns .glitch.local-settings__page__item {
+  background: var(--color-dark);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  margin-bottom: 10px;
+  padding: 12px;
+}
+
+.layout-single-column .glitch.local-settings__page__item.boolean input, .layout-single-column .glitch.local-settings__page__item.radio_buttons input, .layout-multiple-columns .glitch.local-settings__page__item.boolean input, .layout-multiple-columns .glitch.local-settings__page__item.radio_buttons input {
+  accent-color: var(--color-accent);
+}
+
+.layout-single-column .glitch.local-settings__page__item.string input, .layout-single-column .glitch.local-settings__page__item select, .layout-single-column .glitch.local-settings__page__item textarea, .layout-multiple-columns .glitch.local-settings__page__item.string input, .layout-multiple-columns .glitch.local-settings__page__item select, .layout-multiple-columns .glitch.local-settings__page__item textarea {
+  background: var(--color-bg-compose-form);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-badges);
+  color: var(--color-fg);
+}
+
+.layout-single-column .deprecated-settings-info a, .layout-single-column .glitch.local-settings__page__item .hint a, .layout-multiple-columns .deprecated-settings-info a, .layout-multiple-columns .glitch.local-settings__page__item .hint a {
+  color: var(--color-accent);
+}
+
+.layout-single-column .compose-form__buttons > div:has( > .icon-button), .layout-multiple-columns .compose-form__buttons > div:has( > .icon-button) {
+  display: inline-flex;
+}
+
+.layout-single-column .compose-form__buttons > div > .icon-button, .layout-multiple-columns .compose-form__buttons > div > .icon-button {
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  width: 27px;
+  height: 27px;
+  display: inline-flex;
+}
+
+.layout-single-column .compose-form__buttons > div > .icon-button.active, .layout-single-column .compose-form__buttons > div > .icon-button:hover, .layout-single-column .compose-form__buttons > div > .icon-button:focus, .layout-multiple-columns .compose-form__buttons > div > .icon-button.active, .layout-multiple-columns .compose-form__buttons > div > .icon-button:hover, .layout-multiple-columns .compose-form__buttons > div > .icon-button:focus {
+  color: var(--color-accent);
+  background: none;
+}
+
+.layout-single-column .compose-form__poll__footer, .layout-multiple-columns .compose-form__poll__footer {
+  border-top: 1px solid var(--color-border);
+  gap: 10px;
+  margin-top: 10px;
+  padding: 12px 0 0;
+}
+
+.layout-single-column .compose-form__poll__footer__sep, .layout-multiple-columns .compose-form__poll__footer__sep {
+  background: var(--color-border);
+}
+
+.layout-single-column .compose-form__poll__select__label, .layout-multiple-columns .compose-form__poll__select__label {
+  color: var(--color-dim);
+  font-size: var(--font-size-smaller);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+}
+
+.layout-single-column .compose-form__poll__select__value, .layout-multiple-columns .compose-form__poll__select__value {
+  color: var(--color-accent);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight-semibold);
+  background: none;
+  border: 0;
+  outline: 0;
+}
+
+.layout-single-column .status__info__icons, .layout-multiple-columns .status__info__icons {
+  color: var(--color-dim);
+  order: 2;
+  align-items: center;
+  gap: 4px;
+  display: inline-flex;
+}
+
+.layout-single-column .status__info__icons .icon, .layout-multiple-columns .status__info__icons .icon {
+  width: 16px;
+  height: 16px;
+}
+
+.layout-single-column .status__prepend__icon, .layout-multiple-columns .status__prepend__icon {
+  color: var(--color-dim);
+}
+
+.layout-single-column .status__quote-cancel, .layout-multiple-columns .status__quote-cancel {
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+}
+
+.layout-single-column .status__quote-cancel:hover, .layout-single-column .status__quote-cancel:focus, .layout-multiple-columns .status__quote-cancel:hover, .layout-multiple-columns .status__quote-cancel:focus {
+  background: var(--color-column-link-hover);
+  border-color: var(--color-light-text);
+  color: var(--color-light-text);
+}
+
+.layout-single-column .detailed-status__quotes, .layout-multiple-columns .detailed-status__quotes {
+  font-size: var(--font-size);
+  gap: 4px;
+  display: inline-flex;
+}
+
+.layout-single-column .detailed-status__meta .detailed-status__quotes .animated-number, .layout-multiple-columns .detailed-status__meta .detailed-status__quotes .animated-number {
+  color: var(--color-light-text);
+  font-weight: var(--font-weight-bold);
+}
+
+.layout-single-column .detailed-status__link > .icon-quote + span:after, .layout-multiple-columns .detailed-status__link > .icon-quote + span:after {
+  color: var(--color-dim);
+  content: "Quotes";
+  font-weight: var(--font-weight-semibold);
+}
+
+.layout-single-column .detailed-status__meta .detailed-status__link .icon-quote, .layout-multiple-columns .detailed-status__meta .detailed-status__link .icon-quote {
+  display: none;
+}
+
+.layout-single-column .privacy-dropdown__option__additional, .layout-multiple-columns .privacy-dropdown__option__additional {
+  color: var(--color-dim);
+  font-size: var(--font-size-smaller);
+}
+
+.layout-single-column .privacy-dropdown__option__icon, .layout-multiple-columns .privacy-dropdown__option__icon {
+  color: var(--color-accent);
+}
+
+@media (width <= 630px) {
+  .layout-single-column .glitch.local-settings__navigation, .layout-multiple-columns .glitch.local-settings__navigation {
+    width: 48px;
+  }
+
+  .layout-single-column .glitch.local-settings__navigation__item, .layout-multiple-columns .glitch.local-settings__navigation__item {
+    justify-content: center;
+    padding: 12px;
+  }
 }
 
 .error .dialog .dialog__message p, .error .dialog .dialog__message h1 {

--- a/scripts/install-to-mastodon.sh
+++ b/scripts/install-to-mastodon.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
-# Mastodon Bird UI - Install to Mastodon Core
+# Mastodon Bird UI - Install as a glitch-soc skin for the glitch flavour
 # https://github.com/ronilaukkarinen/mastodon-bird-ui
-# Author: Roni Laukkarinen (@rolle@mementomori.social)
 #
-# This script installs/updates Bird UI files in your Mastodon installation.
-# It is idempotent - safe to run multiple times. It will:
-#   - Copy/update all Bird UI module files
-#   - Ensure entry point SCSS files exist (creates missing ones, preserves existing)
-#   - Rebuild themes.yml from scratch (removes stale entries pointing to missing files)
-#   - Ensure locale entries exist
+# glitch-soc does not use upstream Mastodon's config/themes.yml site-theme
+# pipeline. Its default frontend is the `glitch` flavour, and CSS-only themes
+# for that frontend are installed as skins under:
+#   app/javascript/skins/glitch/<skin-name>/common.scss
 #
 # Usage: sudo bash scripts/install-to-mastodon.sh --path /opt/mastodon
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -29,7 +26,24 @@ SET_DEFAULT=""
 # Get script directory and version
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$SCRIPT_DIR/../src"
-VERSION=$(grep -m1 '^### ' "$SCRIPT_DIR/../CHANGELOG.md" | sed 's/### \([^:]*\):.*/\1/')
+VERSION=$(grep -m1 -E '^### [0-9]' "$SCRIPT_DIR/../CHANGELOG.md" | sed 's/### \([^:]*\):.*/\1/' | tr -d '\r' || true)
+VERSION=${VERSION:-unknown}
+
+usage() {
+  echo "Usage: sudo bash $0 [-p|--path /path/to/glitch-soc] [-v|--variations] [-d|--default]"
+  echo ""
+  echo "Installs Mastodon Bird UI as a glitch-soc skin for the glitch flavour."
+  echo ""
+  echo "Options:"
+  echo "  -p, --path        Path to glitch-soc/Mastodon installation"
+  echo "  -v, --variations  Add accessible skin variations"
+  echo "  -d, --default     Set the server default flavour/skin to glitch/Mastodon Bird UI"
+  echo "  -h, --help        Show this help message"
+  echo ""
+  echo "Examples:"
+  echo "  sudo bash $0 --path /opt/mastodon"
+  echo "  sudo bash $0 --path /opt/mastodon --variations --default"
+}
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -47,321 +61,254 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     -h|--help)
-      echo "Usage: sudo bash $0 [-p|--path /path/to/mastodon] [-v|--variations]"
-      echo ""
-      echo "This script is idempotent - safe to run repeatedly."
-      echo "It ensures Bird UI is correctly installed regardless of prior state."
-      echo ""
-      echo "Options:"
-      echo "  -p, --path        Path to Mastodon installation"
-      echo "  -v, --variations  Add accessible theme variations (contrast, accessible, accessible-plus)"
-      echo "  -d, --default     Set Mastodon Bird UI (Dark) as the server default theme"
-      echo "  -h, --help        Show this help message"
-      echo ""
-      echo "Examples:"
-      echo "  # Install or update Bird UI:"
-      echo "  sudo bash $0 --path /opt/mastodon"
-      echo ""
-      echo "  # Install with all variations:"
-      echo "  sudo bash $0 --path /opt/mastodon --variations"
+      usage
       exit 0
       ;;
     *)
       echo -e "${RED}Unknown option: $1${NC}"
+      usage
       exit 1
       ;;
   esac
 done
 
-# Check if Mastodon path is provided
+# Check if Mastodon path is provided. Keep non-interactive installs safe by
+# failing fast when stdin is not a TTY.
 if [ -z "$MASTODON_PATH" ]; then
-  echo -e "${YELLOW}Mastodon path not specified.${NC}"
-  read -p "Enter your Mastodon installation path: " MASTODON_PATH
+  if [ -t 0 ]; then
+    echo -e "${YELLOW}glitch-soc path not specified.${NC}"
+    read -r -p "Enter your glitch-soc installation path: " MASTODON_PATH
+  else
+    echo -e "${RED}Error: --path is required in non-interactive mode.${NC}"
+    exit 1
+  fi
 fi
 
-# Validate Mastodon path
+# Validate Mastodon/glitch-soc path
 if [ ! -d "$MASTODON_PATH" ]; then
   echo -e "${RED}Error: Directory not found: $MASTODON_PATH${NC}"
   exit 1
 fi
 
-STYLES_PATH="$MASTODON_PATH/app/javascript/styles"
-THEMES_FILE="$MASTODON_PATH/config/themes.yml"
-BIRD_UI_PATH="$STYLES_PATH/mastodon-bird-ui"
+FLAVOUR_DIR="$MASTODON_PATH/app/javascript/flavours/glitch"
+GLITCH_THEME_FILE="$FLAVOUR_DIR/theme.yml"
+SKINS_ROOT="$MASTODON_PATH/app/javascript/skins/glitch"
+BASE_SKIN="mastodon-bird-ui"
+BASE_SKIN_PATH="$SKINS_ROOT/$BASE_SKIN"
+BASE_MODULE_PATH="$BASE_SKIN_PATH/mastodon-bird-ui"
+SETTINGS_FILE="$MASTODON_PATH/config/settings.yml"
 
-if [ ! -d "$STYLES_PATH" ]; then
-  echo -e "${RED}Error: Styles directory not found: $STYLES_PATH${NC}"
+if [ ! -f "$GLITCH_THEME_FILE" ]; then
+  echo -e "${RED}Error: glitch flavour not found at $GLITCH_THEME_FILE${NC}"
+  echo "This installer targets glitch-soc. For upstream Mastodon custom CSS, use dist/mastodon-bird-ui.css instead."
   exit 1
 fi
 
-if [ ! -f "$THEMES_FILE" ]; then
-  echo -e "${RED}Error: themes.yml not found: $THEMES_FILE${NC}"
+if [ ! -d "$SKINS_ROOT" ]; then
+  echo -e "${RED}Error: Skins directory not found: $SKINS_ROOT${NC}"
   exit 1
 fi
 
-echo -e "${GREEN}Mastodon Bird UI $VERSION${NC}"
+if [ ! -f "$SETTINGS_FILE" ]; then
+  echo -e "${RED}Error: settings.yml not found: $SETTINGS_FILE${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Mastodon Bird UI $VERSION for glitch-soc${NC}"
 echo ""
 
-# Ask about variations if not specified via flag
+# Ask about variations if not specified via flag. Default to no when running
+# non-interactively.
 if [ -z "$ADD_VARIATIONS" ]; then
-  read -p "Add/update accessible theme variations (contrast, accessible, accessible-plus)? [y/N]: " ADD_VARIATIONS
-  ADD_VARIATIONS=${ADD_VARIATIONS:-n}
+  if [ -t 0 ]; then
+    read -r -p "Add/update accessible skin variations? [y/N]: " ADD_VARIATIONS
+    ADD_VARIATIONS=${ADD_VARIATIONS:-n}
+  else
+    ADD_VARIATIONS="n"
+  fi
 fi
 
-# --- Step 1: Copy module files ---
-echo -e "${BLUE}[1/4] Updating Bird UI module files...${NC}"
+# --- Step 1: Copy module files into the base skin ---
+echo -e "${BLUE}[1/4] Updating Bird UI skin module files...${NC}"
 
-mkdir -p "$BIRD_UI_PATH"
-mkdir -p "$BIRD_UI_PATH/components"
-mkdir -p "$BIRD_UI_PATH/components/profile"
-mkdir -p "$BIRD_UI_PATH/components/profile/icons"
-mkdir -p "$BIRD_UI_PATH/layouts"
-mkdir -p "$BIRD_UI_PATH/micro-interactions"
-mkdir -p "$BIRD_UI_PATH/variables"
-mkdir -p "$BIRD_UI_PATH/variants"
+mkdir -p "$BASE_MODULE_PATH/components/profile/icons"
+mkdir -p "$BASE_MODULE_PATH/layouts"
+mkdir -p "$BASE_MODULE_PATH/micro-interactions"
+mkdir -p "$BASE_MODULE_PATH/variables"
+mkdir -p "$BASE_MODULE_PATH/variants"
 
 copy_if_exists() {
   local src="$1"
   local dest="$2"
   if [ -f "$src" ]; then
     cp "$src" "$dest"
-    echo -e "  ${GREEN}Updated:${NC} $(basename "$dest")"
-    return 0
+    echo -e "  ${GREEN}Updated:${NC} ${dest#$MASTODON_PATH/app/javascript/}"
   fi
-  return 0
 }
 
 # Core module files
-copy_if_exists "$SRC_DIR/_index.scss" "$BIRD_UI_PATH/_index.scss"
+copy_if_exists "$SRC_DIR/_index.scss" "$BASE_MODULE_PATH/_index.scss"
 
 # Variables
 for f in "$SRC_DIR/variables/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/variables/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/variables/$(basename "$f")"
 done
 
 # Components
 for f in "$SRC_DIR/components/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/components/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/components/$(basename "$f")"
 done
 
 # Profile components
 for f in "$SRC_DIR/components/profile/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/components/profile/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/components/profile/$(basename "$f")"
 done
 
 # Profile icons
 for f in "$SRC_DIR/components/profile/icons/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/components/profile/icons/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/components/profile/icons/$(basename "$f")"
 done
 
 # Layouts
 for f in "$SRC_DIR/layouts/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/layouts/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/layouts/$(basename "$f")"
 done
 
 # Micro-interactions
 for f in "$SRC_DIR/micro-interactions/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/micro-interactions/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/micro-interactions/$(basename "$f")"
 done
 
 # Variants
 for f in "$SRC_DIR/variants/"_*.scss; do
-  [ -f "$f" ] && copy_if_exists "$f" "$BIRD_UI_PATH/variants/$(basename "$f")"
+  [ -f "$f" ] && copy_if_exists "$f" "$BASE_MODULE_PATH/variants/$(basename "$f")"
 done
 
-# Create entry point inside module for Custom CSS build compatibility
-cat > "$BIRD_UI_PATH/mastodon-bird-ui.scss" << 'EOF'
+# Module entry point used by the skin packs.
+cat > "$BASE_MODULE_PATH/mastodon-bird-ui.scss" <<'SCSS'
 @use "index";
-EOF
+SCSS
 
 echo -e "${GREEN}Module files updated.${NC}"
 
-# --- Step 2: Ensure entry point SCSS files exist ---
+write_skin_names() {
+  local skin_path="$1"
+  local skin_key="$2"
+  local en_name="$3"
+  local ko_name="$4"
+
+  cat > "$skin_path/names.yml" <<YAML
+en:
+  skins:
+    glitch:
+      $skin_key: $en_name
+ko:
+  skins:
+    glitch:
+      $skin_key: $ko_name
+YAML
+}
+
+# --- Step 2: Create glitch-soc skin packs ---
 echo ""
-echo -e "${BLUE}[2/4] Ensuring entry point SCSS files...${NC}"
+echo -e "${BLUE}[2/4] Writing glitch skin packs...${NC}"
 
-# Helper: create entry point only if missing (preserves any local edits)
-ensure_entry_point() {
-  local file="$1"
-  local content="$2"
-  local name
-  name=$(basename "$file")
-  echo "$content" > "$file"
-  echo -e "  ${GREEN}Updated:${NC} $name"
-}
-
-# Auto bundle - respects data-color-scheme attribute and prefers-color-scheme.
-# Replaces the old separate Dark/Light theme entries; Mastodon's Appearance
-# radios drive the scheme.
-ensure_entry_point "$STYLES_PATH/mastodon-bird-ui-auto.scss" "@use 'application';
+cat > "$BASE_SKIN_PATH/common.scss" <<'SCSS'
+// Mastodon Bird UI for glitch-soc's glitch flavour.
+//
+// A glitch skin replaces the flavour's common stylesheet instead of layering on
+// top of it, so this pack imports the default glitch application stylesheet
+// first and then applies Bird UI overrides.
+@use '@/flavours/glitch/styles/application';
 @use 'mastodon-bird-ui';
-@use 'mastodon-bird-ui/variables/light-mixin' as light;
+SCSS
+write_skin_names "$BASE_SKIN_PATH" "$BASE_SKIN" "Mastodon Bird UI" "유사 트위터"
+echo -e "  ${GREEN}Updated:${NC} skins/glitch/$BASE_SKIN/common.scss"
 
-[data-color-scheme=\"light\"] {
-  @include light.tokens;
-}
-
-@media (prefers-color-scheme: light) {
-  html:not([data-color-scheme]) {
-    @include light.tokens;
-  }
-}"
-
-# Variation entry points
 if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
-  echo ""
-  echo "  Creating variation entry points..."
+  ACCESSIBLE_SKIN_PATH="$SKINS_ROOT/mastodon-bird-ui-accessible"
+  ACCESSIBLE_PLUS_SKIN_PATH="$SKINS_ROOT/mastodon-bird-ui-accessible-plus"
+  mkdir -p "$ACCESSIBLE_SKIN_PATH" "$ACCESSIBLE_PLUS_SKIN_PATH"
 
-  ensure_entry_point "$STYLES_PATH/mastodon-bird-ui-accessible.scss" "@use 'application';
-@use 'mastodon-bird-ui';
-@use 'mastodon-bird-ui/variants/accessible';"
+  cat > "$ACCESSIBLE_SKIN_PATH/common.scss" <<'SCSS'
+// Accessible Mastodon Bird UI for glitch-soc's glitch flavour.
+@use '@/flavours/glitch/styles/application';
+@use '../mastodon-bird-ui/mastodon-bird-ui';
+@use '../mastodon-bird-ui/mastodon-bird-ui/variants/accessible';
+SCSS
+  write_skin_names "$ACCESSIBLE_SKIN_PATH" "mastodon-bird-ui-accessible" "Mastodon Bird UI (Accessible)" "유사 트위터 (접근성)"
+  echo -e "  ${GREEN}Updated:${NC} skins/glitch/mastodon-bird-ui-accessible/common.scss"
 
-  cat > "$BIRD_UI_PATH/mastodon-bird-ui-accessible.scss" << 'EOF'
-@use "index";
-@use "variants/accessible";
-EOF
-
-  ensure_entry_point "$STYLES_PATH/mastodon-bird-ui-accessible-plus.scss" "@use 'application';
-@use 'mastodon-bird-ui';
-@use 'mastodon-bird-ui/variants/accessible-plus';"
-
-  cat > "$BIRD_UI_PATH/mastodon-bird-ui-accessible-plus.scss" << 'EOF'
-@use "index";
-@use "variants/accessible-plus";
-EOF
+  cat > "$ACCESSIBLE_PLUS_SKIN_PATH/common.scss" <<'SCSS'
+// Accessible Plus Mastodon Bird UI for glitch-soc's glitch flavour.
+@use '@/flavours/glitch/styles/application';
+@use '../mastodon-bird-ui/mastodon-bird-ui';
+@use '../mastodon-bird-ui/mastodon-bird-ui/variants/accessible-plus';
+SCSS
+  write_skin_names "$ACCESSIBLE_PLUS_SKIN_PATH" "mastodon-bird-ui-accessible-plus" "Mastodon Bird UI (Accessible Plus)" "유사 트위터 (접근성 플러스)"
+  echo -e "  ${GREEN}Updated:${NC} skins/glitch/mastodon-bird-ui-accessible-plus/common.scss"
 fi
 
-# --- Step 3: Rebuild themes.yml ---
+# --- Step 3: Optionally update server defaults ---
 if [ -z "$SET_DEFAULT" ]; then
-  read -p "Set Mastodon Bird UI (Dark) as the server default theme? [y/N]: " SET_DEFAULT
-  SET_DEFAULT=${SET_DEFAULT:-n}
-fi
-
-echo ""
-echo -e "${BLUE}[3/4] Rebuilding themes.yml...${NC}"
-
-# Helper: add a theme entry, verifying the SCSS file actually exists
-add_theme_entry() {
-  local key="$1"
-  local value="$2"
-  local scss_file="$MASTODON_PATH/app/javascript/$value"
-  if [ -f "$scss_file" ]; then
-    echo "${key}: ${value}" >> "$THEMES_FILE"
-    echo -e "  ${GREEN}Added:${NC} $key"
+  if [ -t 0 ]; then
+    read -r -p "Set glitch/Mastodon Bird UI as the server default flavour and skin? [y/N]: " SET_DEFAULT
+    SET_DEFAULT=${SET_DEFAULT:-n}
   else
-    echo -e "  ${YELLOW}Skipped:${NC} $key (${value} not found)"
+    SET_DEFAULT="n"
   fi
-}
-
-# Set default theme entry
-if [[ "$SET_DEFAULT" =~ ^[Yy]$ ]]; then
-  echo "default: styles/mastodon-bird-ui-auto.scss" > "$THEMES_FILE"
-  echo -e "  ${GREEN}Set:${NC} default: styles/mastodon-bird-ui-auto.scss (Bird UI)"
-  add_theme_entry "mastodon-dark" "styles/application.scss"
-else
-  echo "default: styles/application.scss" > "$THEMES_FILE"
-  echo -e "  ${GREEN}Set:${NC} default: styles/application.scss"
-  add_theme_entry "mastodon-bird-ui-auto" "styles/mastodon-bird-ui-auto.scss"
 fi
 
-# Bird UI variations
-if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
-  add_theme_entry "mastodon-bird-ui-accessible" "styles/mastodon-bird-ui-accessible.scss"
-  add_theme_entry "mastodon-bird-ui-accessible-plus" "styles/mastodon-bird-ui-accessible-plus.scss"
-fi
-
-# --- Step 4: Update locale files ---
 echo ""
-echo -e "${BLUE}[4/4] Updating locale files...${NC}"
+echo -e "${BLUE}[3/4] Updating glitch-soc defaults...${NC}"
 
-EN_LOCALE="$MASTODON_PATH/config/locales/en.yml"
-KO_LOCALE="$MASTODON_PATH/config/locales/ko.yml"
-
-# Clean up stale locale entries from old theme system (removed in Mastodon #37612)
-remove_stale_locale_entry() {
-  local file="$1"
-  local key="$2"
-  local lang="$3"
-
-  [ ! -f "$file" ] && return
-
-  if grep -q "^    ${key}:" "$file"; then
-    sed -i "/^    ${key}:/d" "$file"
-    echo -e "  ${YELLOW}Removed from $lang:${NC} $key (stale)"
-  fi
-}
-
-STALE_THEME_KEYS="mastodon-dark mastodon-light contrast system mastodon-bird-ui-dark mastodon-bird-ui-light mastodon-bird-ui-contrast mastodon-bird-ui-dark-change-to-stars hide-finnish hide-finnish-change-to-stars hide-translate-links mastodon-bird-ui-light-hide-finnish mastodon-bird-ui-light-hide-finnish-change-to-stars mastodon-bird-ui-light-hide-translate-links mastodon-bird-ui-accessible-hide-finnish"
-
-for locale_file in "$EN_LOCALE" "$KO_LOCALE"; do
-  [ ! -f "$locale_file" ] && continue
-  lang=$(basename "$locale_file")
-  for stale_key in $STALE_THEME_KEYS; do
-    remove_stale_locale_entry "$locale_file" "$stale_key" "$lang"
-  done
-done
-
-# Set the 'default' locale label based on whether Bird UI is the default theme
 if [[ "$SET_DEFAULT" =~ ^[Yy]$ ]]; then
-  sed -i "s/^    default: Mastodon.*/    default: Mastodon Bird UI/" "$EN_LOCALE"
-  sed -i "s/^    default: Mastodon.*/    default: Mastodon Bird UI/" "$KO_LOCALE"
-  echo -e "  ${GREEN}Set:${NC} default locale -> Mastodon Bird UI"
+  sed -i "s/^  flavour: .*/  flavour: 'glitch'/" "$SETTINGS_FILE"
+  sed -i "s/^  skin: .*/  skin: '$BASE_SKIN'/" "$SETTINGS_FILE"
+  echo -e "  ${GREEN}Set:${NC} config/settings.yml default flavour: glitch"
+  echo -e "  ${GREEN}Set:${NC} config/settings.yml default skin: $BASE_SKIN"
+  echo -e "  ${YELLOW}Note:${NC} Existing database-backed admin settings may override config/settings.yml."
+  echo "        If needed, set the default flavour/skin in Administration > Server settings, or run:"
+  echo "        RAILS_ENV=production bin/tootctl settings set flavour glitch"
+  echo "        RAILS_ENV=production bin/tootctl settings set skin $BASE_SKIN"
 else
-  sed -i "s/^    default: Mastodon Bird UI.*/    default: Mastodon/" "$EN_LOCALE" 2>/dev/null
-  sed -i "s/^    default: Mastodon Bird UI.*/    default: Mastodon/" "$KO_LOCALE" 2>/dev/null
+  echo -e "  ${YELLOW}Skipped:${NC} Server default unchanged. Users can select the skin in Preferences > Flavours."
 fi
 
-add_locale_entry() {
-  local file="$1"
-  local key="$2"
-  local value="$3"
-  local lang="$4"
-
-  [ ! -f "$file" ] && return
-
-  if ! grep -q "^    ${key}:" "$file"; then
-    if grep -q "^  themes:" "$file"; then
-      sed -i "/^  themes:/a\\    ${key}: ${value}" "$file"
-      echo -e "  ${GREEN}Added to $lang:${NC} $key"
-    fi
-  fi
-}
-
-# Core theme locale entries
-if [[ "$SET_DEFAULT" =~ ^[Yy]$ ]]; then
-  # Bird UI is default, so add locale for the stock Mastodon theme
-  add_locale_entry "$EN_LOCALE" "mastodon-dark" "Mastodon" "en.yml"
-  add_locale_entry "$KO_LOCALE" "mastodon-dark" "Mastodon" "ko.yml"
-else
-  add_locale_entry "$EN_LOCALE" "mastodon-bird-ui-auto" "Mastodon Bird UI" "en.yml"
-  add_locale_entry "$KO_LOCALE" "mastodon-bird-ui-auto" "유사 트위터" "ko.yml"
-fi
-
-# Variation locale entries
-if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
-  add_locale_entry "$EN_LOCALE" "mastodon-bird-ui-accessible" "Mastodon Bird UI (Accessible)" "en.yml"
-  add_locale_entry "$EN_LOCALE" "mastodon-bird-ui-accessible-plus" "Mastodon Bird UI (Accessible Plus)" "en.yml"
-
-  add_locale_entry "$KO_LOCALE" "mastodon-bird-ui-accessible" "유사 트위터 (접근성)" "ko.yml"
-  add_locale_entry "$KO_LOCALE" "mastodon-bird-ui-accessible-plus" "유사 트위터 (접근성 플러스)" "ko.yml"
-fi
-
-# --- Fix ownership and permissions ---
+# --- Step 4: Fix ownership and permissions ---
 echo ""
-echo "Fixing file ownership and permissions..."
-chmod -R a+r "$BIRD_UI_PATH"
-find "$BIRD_UI_PATH" -type d -exec chmod a+rx {} \;
-chown -R mastodon:mastodon "$BIRD_UI_PATH"
-chown mastodon:mastodon "$STYLES_PATH"/mastodon-bird-ui-*.scss 2>/dev/null || true
-chown mastodon:mastodon "$STYLES_PATH"/hide-*.scss 2>/dev/null || true
-chown mastodon:mastodon "$THEMES_FILE"
+echo -e "${BLUE}[4/4] Fixing file ownership and permissions...${NC}"
+chmod -R a+r "$BASE_SKIN_PATH"
+find "$BASE_SKIN_PATH" -type d -exec chmod a+rx {} \;
+
+if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
+  chmod -R a+r "$SKINS_ROOT/mastodon-bird-ui-accessible" "$SKINS_ROOT/mastodon-bird-ui-accessible-plus"
+  find "$SKINS_ROOT/mastodon-bird-ui-accessible" "$SKINS_ROOT/mastodon-bird-ui-accessible-plus" -type d -exec chmod a+rx {} \;
+fi
+
+if id mastodon >/dev/null 2>&1; then
+  chown -R mastodon:mastodon "$BASE_SKIN_PATH"
+  if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
+    chown -R mastodon:mastodon "$SKINS_ROOT/mastodon-bird-ui-accessible" "$SKINS_ROOT/mastodon-bird-ui-accessible-plus"
+  fi
+  chown mastodon:mastodon "$SETTINGS_FILE"
+else
+  echo -e "  ${YELLOW}Skipped chown:${NC} user 'mastodon' does not exist on this system."
+fi
 
 echo ""
 echo -e "${GREEN}Done!${NC}"
 echo ""
-echo "themes.yml contents:"
-cat "$THEMES_FILE"
+echo "Installed skins:"
+echo "  - glitch/$BASE_SKIN"
+if [[ "$ADD_VARIATIONS" =~ ^[Yy]$ ]]; then
+  echo "  - glitch/mastodon-bird-ui-accessible"
+  echo "  - glitch/mastodon-bird-ui-accessible-plus"
+fi
 echo ""
 echo "Next steps:"
 echo "  cd $MASTODON_PATH"
-echo "  RAILS_ENV=development bundle exec rails assets:precompile && sudo systemctl restart mastodon-web"
+echo "  RAILS_ENV=production bundle exec rails assets:precompile"
+echo "  sudo systemctl restart mastodon-web"
+echo ""
+echo "Users can select the skin in Preferences > Flavours with flavour 'glitch'."

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -95,6 +95,7 @@
 @use "components/list-panel";
 @use "layouts/mobile";
 @use "components/embeds";
+@use "components/glitch-flavour";
 
 // Components
 @use "components/error";

--- a/src/components/_glitch-flavour.scss
+++ b/src/components/_glitch-flavour.scss
@@ -1,0 +1,234 @@
+// glitch-soc flavour compatibility
+// The glitch flavour ships extra React components that do not exist in vanilla
+// Mastodon (local settings, advanced compose controls, quote controls, and
+// extra status metadata). Keep these selectors additive so the Custom CSS build
+// remains safe on upstream Mastodon while the glitch skin gets first-class
+// Bird UI styling.
+.layout-single-column,
+.layout-multiple-columns {
+  // --- Local settings modal -------------------------------------------------
+  .glitch.local-settings {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--dropdown-shadow);
+    color: var(--color-fg);
+    max-height: min(640px, 90vh);
+    max-width: min(860px, 92vw);
+    overflow: hidden;
+  }
+
+  .glitch.local-settings__navigation {
+    background: var(--color-dark);
+    border-right: 1px solid var(--color-border);
+    scrollbar-width: none;
+  }
+
+  .glitch.local-settings__navigation::-webkit-scrollbar,
+  .glitch.local-settings__page::-webkit-scrollbar {
+    display: none;
+    width: 4px;
+  }
+
+  .glitch.local-settings__navigation__item {
+    background: transparent;
+    border-bottom: 0;
+    color: var(--color-light-text);
+    font-size: var(--font-size);
+    font-weight: var(--font-weight-semibold);
+    gap: 10px;
+    padding: 14px 18px;
+    transition:
+      background-color 200ms,
+      color 200ms;
+  }
+
+  .glitch.local-settings__navigation__item.active,
+  .glitch.local-settings__navigation__item:hover,
+  .glitch.local-settings__navigation__item:focus {
+    background: var(--color-column-link-hover);
+    color: var(--color-fg);
+  }
+
+  .glitch.local-settings__navigation__item.close,
+  .glitch.local-settings__navigation__item.close:hover,
+  .glitch.local-settings__navigation__item.close:focus {
+    background: var(--color-red);
+    color: #fff;
+  }
+
+  .glitch.local-settings__page {
+    background: var(--color-bg);
+    color: var(--color-fg);
+    padding: 20px;
+  }
+
+  .glitch.local-settings h1 {
+    color: var(--color-fg);
+    font-size: var(--font-size-heading);
+    font-weight: var(--font-weight-bold);
+  }
+
+  .glitch.local-settings h2,
+  .glitch.local-settings span.hint,
+  .deprecated-settings-info {
+    color: var(--color-dim);
+  }
+
+  .glitch.local-settings__page__item {
+    background: var(--color-dark);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    margin-bottom: 10px;
+    padding: 12px;
+  }
+
+  .glitch.local-settings__page__item.boolean,
+  .glitch.local-settings__page__item.radio_buttons {
+    input {
+      accent-color: var(--color-accent);
+    }
+  }
+
+  .glitch.local-settings__page__item.string input,
+  .glitch.local-settings__page__item select,
+  .glitch.local-settings__page__item textarea {
+    background: var(--color-bg-compose-form);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-badges);
+    color: var(--color-fg);
+  }
+
+  .deprecated-settings-info a,
+  .glitch.local-settings__page__item .hint a {
+    color: var(--color-accent);
+  }
+
+  // --- Advanced compose controls ------------------------------------------
+  .compose-form__buttons > div:has(> .icon-button) {
+    display: inline-flex;
+  }
+
+  .compose-form__buttons > div > .icon-button {
+    align-items: center;
+    border-radius: 50%;
+    display: inline-flex;
+    height: 27px;
+    justify-content: center;
+    width: 27px;
+  }
+
+  .compose-form__buttons > div > .icon-button.active,
+  .compose-form__buttons > div > .icon-button:hover,
+  .compose-form__buttons > div > .icon-button:focus {
+    background: transparent;
+    color: var(--color-accent);
+  }
+
+  .compose-form__poll__footer {
+    border-top: 1px solid var(--color-border);
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px 0 0;
+  }
+
+  .compose-form__poll__footer__sep {
+    background: var(--color-border);
+  }
+
+  .compose-form__poll__select__label {
+    color: var(--color-dim);
+    font-size: var(--font-size-smaller);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+  }
+
+  .compose-form__poll__select__value {
+    background: transparent;
+    border: 0;
+    color: var(--color-accent);
+    font-size: var(--font-size);
+    font-weight: var(--font-weight-semibold);
+    outline: 0;
+  }
+
+  // --- Statuses and quote posts -------------------------------------------
+  .status__info__icons {
+    align-items: center;
+    color: var(--color-dim);
+    display: inline-flex;
+    gap: 4px;
+    order: 2;
+  }
+
+  .status__info__icons .icon {
+    height: 16px;
+    width: 16px;
+  }
+
+  .status__prepend__icon {
+    color: var(--color-dim);
+  }
+
+  .status__quote-cancel {
+    align-items: center;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    display: inline-flex;
+    height: 30px;
+    justify-content: center;
+    width: 30px;
+  }
+
+  .status__quote-cancel:hover,
+  .status__quote-cancel:focus {
+    background: var(--color-column-link-hover);
+    border-color: var(--color-light-text);
+    color: var(--color-light-text);
+  }
+
+  .detailed-status__quotes {
+    display: inline-flex;
+    font-size: var(--font-size);
+    gap: 4px;
+  }
+
+  .detailed-status__meta .detailed-status__quotes .animated-number {
+    color: var(--color-light-text);
+    font-weight: var(--font-weight-bold);
+  }
+
+  .detailed-status__link > .icon-quote + span::after {
+    color: var(--color-dim);
+    content: "Quotes";
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .detailed-status__meta .detailed-status__link .icon-quote {
+    display: none;
+  }
+
+  // --- Quote/privacy dropdown details --------------------------------------
+  .privacy-dropdown__option__additional {
+    color: var(--color-dim);
+    font-size: var(--font-size-smaller);
+  }
+
+  .privacy-dropdown__option__icon {
+    color: var(--color-accent);
+  }
+}
+
+@media (width <= 630px) {
+  .layout-single-column,
+  .layout-multiple-columns {
+    .glitch.local-settings__navigation {
+      width: 48px;
+    }
+
+    .glitch.local-settings__navigation__item {
+      justify-content: center;
+      padding: 12px;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Make Mastodon Bird UI installable as a skin for glitch-soc's `glitch` flavour instead of the upstream site-theme pipeline.  
- Provide first-class styling for glitch-specific UI pieces (local settings, advanced compose controls, quote metadata) so the skin integrates cleanly.  
- Improve installer robustness and UX with non-interactive safety, argument parsing, validation and optional variations/default configuration.

### Description

- Update documentation in `README.md` to describe installing Mastodon Bird UI as a `glitch` skin and adjust example commands to target a `glitch-soc` tree.  
- Replace and refactor the installer `scripts/install-to-mastodon.sh` to target `app/javascript/skins/glitch/<skin>/common.scss`, create skin packs (including accessible variations), write `names.yml` for skin names, validate paths, provide `--variations` and `--default` flags, safer argument parsing/usage, non-interactive behavior, permission fixes and optional updates to `config/settings.yml`.  
- Add glitch-specific SCSS by including a new `components/_glitch-flavour.scss` from `src/_index.scss`; this file contains additive styles for local settings, compose controls, quote UI, privacy dropdowns and responsive tweaks to support glitch components.  
- Rebuilt distribution CSS `dist/mastodon-bird-ui.css` to include the new glitch-related rules and minor icon/path adjustments.

### Testing

- Rebuilt the stylesheet with `npm run build` to regenerate `dist/mastodon-bird-ui.css`, and the build completed successfully.  
- Ran style linting with `npm run lint` and no stylelint errors were reported.  
- No automated unit tests were changed by this PR; the installer script was exercised locally against a development checkout to validate file creation and path checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d4e23a5348321a59fe707253101f9)